### PR TITLE
Add Cloudflare Worker to serve speedtest.ps1 at speed.it2.sh

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,21 @@
+name: Deploy to Cloudflare Workers
+
+on:
+  push:
+    branches:
+      - master
+      - main
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    name: Deploy speedtest worker
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Deploy to Cloudflare Workers
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: c6452865d04ed5bd485084005c60cb02

--- a/worker/index.js
+++ b/worker/index.js
@@ -1,0 +1,43 @@
+// Cloudflare Worker: serves speedtest.ps1 at speed.it2.sh
+// Users run: irm speed.it2.sh | iex
+
+const GITHUB_RAW_URL =
+  "https://github.com/asheroto/speedtest/releases/latest/download/speedtest.ps1";
+
+export default {
+  async fetch(request) {
+    const url = new URL(request.url);
+
+    // Health check
+    if (url.pathname === "/health") {
+      return new Response("OK", { status: 200 });
+    }
+
+    // Fetch the latest release of speedtest.ps1 from GitHub and proxy it
+    const response = await fetch(GITHUB_RAW_URL, {
+      headers: {
+        "User-Agent": "speedtest-worker/1.0",
+        Accept: "application/octet-stream",
+      },
+      redirect: "follow",
+    });
+
+    if (!response.ok) {
+      return new Response(
+        `Failed to fetch speedtest.ps1: ${response.statusText}`,
+        { status: 502 }
+      );
+    }
+
+    const body = await response.text();
+
+    return new Response(body, {
+      status: 200,
+      headers: {
+        "Content-Type": "text/plain; charset=utf-8",
+        "Cache-Control": "public, max-age=3600",
+        "X-Source": "speed.it2.sh",
+      },
+    });
+  },
+};

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,11 @@
+name = "speedtest-pwsh"
+main = "worker/index.js"
+compatibility_date = "2024-11-01"
+compatibility_flags = ["nodejs_compat"]
+
+[observability]
+enabled = true
+
+[[routes]]
+pattern = "speed.it2.sh/*"
+custom_domain = true


### PR DESCRIPTION
- worker/index.js: proxies latest speedtest.ps1 from GitHub releases
- wrangler.toml: configures worker with speed.it2.sh custom domain
- .github/workflows/deploy.yml: auto-deploys on push to master/main

Usage after setup: irm speed.it2.sh | iex

https://claude.ai/code/session_01U9uEd3A9BSiXhDkQfJwsGi